### PR TITLE
Update json_api_client gem to match the flex-ruby and OMS

### DIFF
--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "~> 1.5"
+  spec.add_runtime_dependency "json_api_client", "1.5.3"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "~> 1.0"
+  spec.add_runtime_dependency "json_api_client", "~> 1.5"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
Relates to https://github.com/shiftcommerce/flex-ruby-gem/issues/157

Update to `json_api_client` required to ensure the version is matching `flex-ruby-gem` and the oms client gem.