### PR TITLE
Issue: Updates inline with Deployment Engine rails 5 upgrade

### DIFF
--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -17,7 +17,7 @@ module FlexDeploymentClient
     end
 
     def self.upload(attributes)
-      parser.parse(self, connection.run(:post, table_name, { data: { type: :uploaded_files, attributes: attributes } }, custom_headers.merge({ "Content-Type": "multipart/form-data" }))).first
+      parser.parse(self, connection.run(:post, table_name, { data: { type: :uploaded_files, attributes: attributes } }, custom_headers.merge({ "Content-Type": "application/vnd.api+json" }))).first
     end
   end
 end

--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "~> 1.5"
+  spec.add_runtime_dependency "json_api_client", "1.5.3"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "~> 1.0"
+  spec.add_runtime_dependency "json_api_client", "~> 1.5"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
***NOTE: Based on json api gem updates in https://github.com/shiftcommerce/flex_deployment_client/pull/5***

## Overview

Related GitHub Issue: https://github.com/shiftcommerce/flex_deployment_client/issues/6
Related PRs: https://github.com/shiftcommerce/shift-deployment/pull/161

This PR updates the gem inline with the rails 5 shift deployment upgrade - https://github.com/shiftcommerce/shift-deployment/pull/161

## QA Steps

1.) Deploy  platform branch [`issue/flex_deployment_client_updates`](https://github.com/shiftcommerce/flex-platform/pull/7279) on DEV (contains the updated gem) as well as  shift deployment engine branch - [`issue/issue/159_rails_upgrade`](https://github.com/shiftcommerce/shift-deployment/pull/161) on DEV

2.) Deploy an environment via the Admin panel -https://integration.dev.shiftuat.com/admin/environments/new

![Deployed Environment](https://user-images.githubusercontent.com/4486874/45945916-09f1eb00-bfe7-11e8-8ee7-450481f794ff.png)

3.) Ensure that the environment deployed successfully by visiting the environment url

![Environment](https://user-images.githubusercontent.com/4486874/45945913-078f9100-bfe7-11e8-9f32-7090069b1f86.png)

4.) Test sad path:

i.) Deploy an invalid theme, eg. without a Gemfile -
 https://github.com/shiftcommerce/matalan-rails-site/tree/_deployment_mmqa .

ii.) Check that the error message includes a link to the `output_stream_url`.

![invalid Environment](https://user-images.githubusercontent.com/4486874/45946084-a87e4c00-bfe7-11e8-810b-7207221ff0b3.png)

## Code Review

All files

## Deployment

N/A