### PR TITLE
Release: v0.1.6

### DIFF
--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -1,6 +1,11 @@
 module FlexDeploymentClient
   class Pipeline < ModelBase
+    
     has_many :deployments, class_name: "::FlexDeploymentClient::Deployment"
+
+    def name
+      self[:name]
+    end
 
   end
 end

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -17,7 +17,7 @@ module FlexDeploymentClient
     end
 
     def self.upload(attributes)
-      parser.parse(self, connection.run(:post, table_name, { data: { type: :uploaded_files, attributes: attributes } }, custom_headers.merge({ "Content-Type": "multipart/form-data" }))).first
+      parser.parse(self, connection.run(:post, table_name, { data: { type: :uploaded_files, attributes: attributes } }, custom_headers.merge({ "Content-Type": "application/vnd.api+json" }))).first
     end
   end
 end

--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "~> 1.5"
+  spec.add_runtime_dependency "json_api_client", "1.5.3"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_runtime_dependency "json_api_client", "~> 1.0"
   spec.add_runtime_dependency "oj"
-  spec.add_runtime_dependency "mime-types", "~> 3.1"
+  spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"

--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "~> 1.0"
+  spec.add_runtime_dependency "json_api_client", "~> 1.5"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/flex_deployment_client/version.rb
+++ b/lib/flex_deployment_client/version.rb
@@ -1,3 +1,3 @@
 module FlexDeploymentClient
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
## Overview

Release includes updates from the following PRs:

- [x] Update json_api_client gem to match the flex-ruby and OMS - https://github.com/shiftcommerce/flex_deployment_client/pull/5
- [x] Issue: Updates inline with Deployment Engine rails 5 upgrade - https://github.com/shiftcommerce/flex_deployment_client/pull/7
- [x] Issue: Pipeline Integration - https://github.com/shiftcommerce/flex_deployment_client/pull/3