### PR TITLE
update run time dependency to match that of flex-ruby-gem

### DIFF
--- a/flex_deployment_client.gemspec
+++ b/flex_deployment_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "json_api_client", "1.5.3"
+  spec.add_runtime_dependency "json_api_client", "1.1.1"
   spec.add_runtime_dependency "oj"
   spec.add_runtime_dependency "mime-types", ">= 2.99", "<= 3.1"
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/flex_deployment_client/version.rb
+++ b/lib/flex_deployment_client/version.rb
@@ -1,3 +1,3 @@
 module FlexDeploymentClient
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
The latest version of the flex-ruby-gem has a ruby time dependency of `spec.add_runtime_dependency "json_api_client", "1.1.1"` the deployment client needs to match this so that the flex-platform can be updated to use the latest version of flex-ruby-gem. 

At the time of writing this it is - https://github.com/shiftcommerce/flex-ruby-gem/releases/tag/v0.6.55